### PR TITLE
fix: align storage metadata GPRC bind port with other variable names

### DIFF
--- a/changelog/unreleased/fix-storage-metadata-env-var-name.md
+++ b/changelog/unreleased/fix-storage-metadata-env-var-name.md
@@ -1,0 +1,5 @@
+Bugfix: Align storage metadata GPRC bind port with other variable names
+
+Changed STORAGE_METADATA_GRPC_PROVIDER_ADDR to STORAGE_METADATA_GRPC_ADDR so it aligns with standard environment variable naming conventions used in oCIS.
+
+https://github.com/owncloud/ocis/pull/3169

--- a/storage/pkg/config/config.go
+++ b/storage/pkg/config/config.go
@@ -1234,7 +1234,7 @@ func structMappings(cfg *Config) []shared.EnvBinding {
 			Destination: &cfg.Reva.StorageMetadata.GRPCNetwork,
 		},
 		{
-			EnvVars:     []string{"STORAGE_METADATA_GRPC_PROVIDER_ADDR"},
+			EnvVars:     []string{"STORAGE_METADATA_GRPC_ADDR"},
 			Destination: &cfg.Reva.StorageMetadata.GRPCAddr,
 		},
 		{


### PR DESCRIPTION
## Description
Currently **STORAGE_METADATA_GRPC_PROVIDER_ADDR** environment variable used as the way to set the GRPC bind port for the service.  All other services use the format **<SERVICE_NAME>_GRPC_ADDR for GRPC**, and **<SERVICE_NAME>_HTTP_ADDR** for HTTP.

## Motivation and Context
This change brings it in line with the others, as it's confusing why this one is different.

## How Has This Been Tested?
Simple test is to run the following:

`docker run -d --name ocis -e OCIS_RUN_EXTENSIONS="storage-metadata" -e STORAGE_METADATA_GRPC_ADDR="0.0.0.0:9215" owncloud/ocis`

Check port this service is bound to (expect it to bind to external address):
`docker exec -it ocis /usr/bin/nc -zv 172.17.0.2:9215`

Expect to see:
`172.17.0.2:9215 (172.17.0.2:9215) open`

## Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

This is possibly a breaking change but a search of the source code finds no specific references to this variable anywhere.

## Checklist:
- [x] Code changes
